### PR TITLE
Just use ubuntu-latest in the GitHub workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -10,16 +10,9 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
-    container:
-      image: fedora:latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install deps
-        run: |
-          dnf -y install make podman skopeo
 
       - name: Build
         run: |


### PR DESCRIPTION
I had the idea that I needed Fedora to use podman and skopeo, but actually I'm getting errors trying to use podman inside the container. I expect there is a solution for that, but in the short term, let's use whatever works.

It seems like GitHub's ubuntu-latest already has the tools we need, so no need to install podman or skopeo.

(I tested this in my fork and I believe the build works.)