### PR TITLE
Use podman not skopeo to push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ PUBLIC_IMG := quay.io/sbaird/jira-mcp
 push:
 	@echo "🛠️ Pushing to $(PUBLIC_IMG)"
 	@for tag in latest git-$(shell git rev-parse --short HEAD); do \
-	  skopeo copy containers-storage:$(IMG) docker://$(PUBLIC_IMG):$$tag; \
+	  podman tag $(IMG) $(PUBLIC_IMG):$$tag; \
+	  podman push $(PUBLIC_IMG):$$tag; \
 	done
 
 # Notes:


### PR DESCRIPTION
I'm getting this kind of error with skopeo when running in the GitHub workflow:

    Error during unshare(...): Operation not permitted

I believe it's related to the "containers-storage" access requiring some permissions that aren't available in the GitHub runners. Rather than figure out a solution, let's just use podman.

This worked in my fork, so I think we're nearly there now.

In hindsight, maybe using something from [here](https://github.com/redhat-actions) would have been smart, but I do like the pattern of very thin workflows that just run make targets that you can test and hack on locally.