### PR TITLE
Nicer handling of required env vars in test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,11 +101,11 @@ fmt-check:
 
 .PHONY: test
 test:
-	@JIRA_URL=https://test.example.com JIRA_API_TOKEN=test-token python -m pytest -v
+	@python -m pytest -v
 
 .PHONY: quiet-test
 quiet-test:
-	@JIRA_URL=https://test.example.com JIRA_API_TOKEN=test-token python -m pytest
+	@python -m pytest
 
 .PHONY: ci
 ci: quiet-test fmt-check

--- a/test_server.py
+++ b/test_server.py
@@ -6,6 +6,10 @@ from unittest.mock import Mock, patch, MagicMock
 from fastapi import HTTPException
 import json
 
+# Set up required environment variables before importing server module
+os.environ["JIRA_URL"] = "https://test.example.com"
+os.environ["JIRA_API_TOKEN"] = "test-token"
+
 # Mock JIRA client creation before importing server module
 with patch("jira.JIRA"):
     # Import the server module


### PR DESCRIPTION
Letting python handle it is much tidier.

This is a fixup for PR #30.