### PR TITLE
Update python base image to 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.13'
         cache: pip
 
     - name: Install dependencies

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
 # Set work directory
 WORKDIR /app


### PR DESCRIPTION
Quay's security scans see [1] are showing we have some CVES. Updating to a newer base image might help with that.

Update the GitHub CI workflow to match the version.

[1] https://quay.io/repository/sbaird/jira-mcp?tab=tags&tag=latest