### PR TITLE
Don't crash if qa_contact field is not present

### DIFF
--- a/server.py
+++ b/server.py
@@ -77,8 +77,8 @@ def search_issues(jql: str, max_results: int = 100) -> str:
                 "status": issue.fields.status.name if issue.fields.status else None,
                 "assignee": (issue.fields.assignee.displayName if issue.fields.assignee else None),
                 "qa_contact": (
-                    getattr(issue.fields, QA_CONTACT_FID).displayName
-                    if getattr(issue.fields, QA_CONTACT_FID)
+                    qa_contact.displayName
+                    if (qa_contact := getattr(issue.fields, QA_CONTACT_FID, None))
                     else None
                 ),
                 "reporter": (issue.fields.reporter.displayName if issue.fields.reporter else None),


### PR DESCRIPTION
Avoid this error:

    Error: Error calling tool 'search_issues': 400: JQL search failed:
    'PropertyHolder' object has no attribute 'customfield_12315948'

See also PR #20 where this field was added.