### PR TITLE
fix: Require authentication from client when running as server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ Here is an example of how to do this using SSE, which is a deprecated http-based
 export $(grep -v '^#' ~/.rh-jira-mcp.env | xargs) && python server.py --transport sse --port 3075
 ```
 
+For either Streamable HTTP or SSE, the JIRA_API_KEY in your environment is ignored (and not neeed).  This is an important security feature, because otherwise anyone who
+had access to the HTTP service would have access to the account information for whoever configured and ran that server.
+Instead, calling applications must send in their own Jira token as a Bearer token.  Here is an example of how to do that using Llama Stack:
+
+```python
+from llama_stack_client import LlamaStackClient
+
+client = LlamaStackClient(base_url=LLAMA_STACK_URL)
+mcp_llama_stack_client_response = client.responses.create(
+    model=LLAMA_STACK_MODEL_ID,
+    input="Tell me about RHAISTRAT-24.",
+    tools=[
+        {
+            "type": "mcp",
+            "server_url": JIRA_MCP_URL,
+            "server_label": "Jira_tools",            
+            "headers": {
+                "Authorization": f"Bearer {JIRA_API_TOKEN}"
+            }
+        }
+    ]
+)
+```
+
 ## Available Tools
 
 This MCP server provides the following tools:


### PR DESCRIPTION
Gordon Sim pointed out on Slack:
> serving over HTTP when using your own access token seems dangerous without very tight control over who can access your http endpoint. Would be better to require the token to be passed a s a bearer token when running over http.

This is a good point.  This PR addresses this in the following way:

- If running in stdio mode, it still uses the JIRA_API_TOKEN environment variable as it always has.  I tested this with Cursor and it still works.
- If running in SSE or Streamable HTTP, it ignores the JIRA_API_TOKEN environment variable if any.  Instead it checks to to see if the calling application has sent it a token.  If it has, it uses that token.  I tested it with both SSE and Streamable HTTP (using Llama Stack), and it works correctly if you send it a valid token.  If you send it an invalid token or no token, that information goes to the model to formulate a reasonable response, e.g., `Response content: It seems that I do not have the necessary permissions to access the details of the Jira issue RHAISTRAT-24. You may need to log in to the appropriate Jira account with the required permissions to view this issue.`
- The README is updated with details about why and how to send an API token to the server.