### PR TITLE
feat: Add a way to get full JSON of the issue so we can get custom fields as well like story points

### DIFF
--- a/client.py
+++ b/client.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+import asyncio
+import argparse
+import sys
+import json
+import traceback
+from mcp.client.streamable_http import streamable_http_client
+from mcp.client.session import ClientSession
+
+# Default URL for FastMCP HTTP (Streamable) transport
+SERVER_URL = "http://localhost:8080/mcp"
+
+
+async def run_mcp_tool(tool_name, arguments):
+    print(f"Connecting to {SERVER_URL}...", file=sys.stderr)
+    try:
+        async with streamable_http_client(SERVER_URL) as streams:
+            async with ClientSession(streams[0], streams[1]) as session:
+                print("Initializing session...", file=sys.stderr)
+                await session.initialize()
+
+                print(
+                    f"Calling tool '{tool_name}' with args: {json.dumps(arguments)}",
+                    file=sys.stderr,
+                )
+                result = await session.call_tool(tool_name, arguments=arguments)
+                return result
+    except Exception as e:
+        traceback.print_exc(file=sys.stderr)
+        print(f"Error during MCP communication: {e}", file=sys.stderr)
+        return None
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Simple Jira MCP Client")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # Search Command
+    search_parser = subparsers.add_parser("search", help="Search issues using JQL")
+    search_parser.add_argument("jql", help="JQL query string")
+    search_parser.add_argument("--limit", type=int, default=10, help="Max results (default: 10)")
+
+    # Get Command
+    get_parser = subparsers.add_parser("get", help="Get detailed issue info")
+    get_parser.add_argument("key", help="Issue Key (e.g., TEST-123)")
+    get_parser.add_argument("--extra", nargs="+", default=[], help="List of extra fields to fetch")
+
+    # Create Command
+    create_parser = subparsers.add_parser("create", help="Create a new issue")
+    create_parser.add_argument("summary", help="Issue Summary")
+    create_parser.add_argument("--project", required=True, help="Project Key")
+    create_parser.add_argument("--desc", default="", help="Description")
+    create_parser.add_argument("--type", default="Task", help="Issue Type")
+    create_parser.add_argument("--priority", help="Priority")
+    create_parser.add_argument("--assignee", help="Assignee username")
+    # Example of hardcoded/flexible extra fields
+    create_parser.add_argument("--labels", nargs="+", help="Labels to add (example of extra field)")
+
+    # Update Command
+    update_parser = subparsers.add_parser("update", help="Update an existing issue")
+    update_parser.add_argument("key", help="Issue Key (e.g., TEST-123)")
+    update_parser.add_argument("--summary", help="New Summary")
+    update_parser.add_argument("--desc", help="New Description")
+    update_parser.add_argument("--priority", help="New Priority")
+    update_parser.add_argument("--assignee", help="New Assignee")
+
+    args = parser.parse_args()
+
+    if args.command == "search":
+        tool_name = "search_issues"
+        arguments = {
+            "jql": args.jql,
+            "max_results": args.limit,
+            "extra_fields": [
+                "customfield_12313140",
+                "customfield_12311140",
+                "customfield_12310243",
+            ],
+        }
+
+    elif args.command == "get":
+        tool_name = "get_jira"
+        arguments = {"issue_key": args.key, "extra_fields": args.extra}
+
+    elif args.command == "create":
+        tool_name = "create_issue"
+        arguments = {
+            "project_key": args.project,
+            "summary": args.summary,
+            "description": args.desc,
+            "issue_type": args.type,
+            "priority": args.priority,
+        }
+        if args.assignee:
+            arguments["assignee"] = args.assignee
+
+        # Demonstrate usage of extra_fields
+        extra_fields = {}
+        if args.labels:
+            extra_fields["labels"] = args.labels
+
+        if extra_fields:
+            arguments["extra_fields"] = extra_fields
+
+    elif args.command == "update":
+        tool_name = "update_issue"
+        arguments = {"issue_key": args.key}
+        if args.summary:
+            arguments["summary"] = args.summary
+        if args.desc:
+            arguments["description"] = args.desc
+        if args.priority:
+            arguments["priority"] = args.priority
+        if args.assignee:
+            arguments["assignee"] = args.assignee
+
+    # Execute
+    result = await run_mcp_tool(tool_name, arguments)
+
+    if result:
+        print("\n--- Result ---\n")
+        # Handle different content types if necessary, but usually it's TextContent
+        for content in result.content:
+            if hasattr(content, "text"):
+                print(content.text)
+            else:
+                print(str(content))
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/server.py
+++ b/server.py
@@ -80,8 +80,8 @@ def get_jira(issue_key: str, extra_fields: list = []) -> str:
     """
     Fetch the Jira issue identified by 'issue_key' then
     return a Markdown string: "# ISSUE-KEY: summary\n\ndescription".
-    If 'extra_fields' were provided, they will be added to the returned
-    string: "# ISSUE: summary\n\ndescription\n\nkey1 = value1\n..."
+    If 'extra_fields=["key1","key2"]' were provided, they will be added to the returned
+    string: "# ISSUE: summary\n\ndescription\n\nkey1 = value1\nkey2 = value2\n..."
     """
     issue = _get_jira(issue_key)
 
@@ -91,7 +91,7 @@ def get_jira(issue_key: str, extra_fields: list = []) -> str:
 
     output = f"# {issue_key}: {summary}\n\n{description}"
 
-    # If extra fields were requested, add the to the output as well
+    # If extra fields were requested, add them to the output as well
     if extra_fields:
         output += "\n"
         for k in extra_fields:

--- a/server.py
+++ b/server.py
@@ -134,7 +134,7 @@ def search_issues(jql: str, max_results: int = 100, extra_fields: list | None = 
 
     extra_fields = extra_fields or []
 
-    def simplify_issue(issue, extra_fields):
+    def simplify_issue(issue):
         """Extract only essential fields to avoid token limit issues"""
 
         def get_field_value(field):

--- a/server.py
+++ b/server.py
@@ -338,8 +338,20 @@ def create_issue(
     issue_type: str = "Task",
     priority: str = "Medium",
     assignee: str = None,
+    extra_fields: dict = {},
 ) -> str:
-    """Create a new Jira issue."""
+    """
+    Create a new Jira issue.
+
+    Args:
+        project_key: The project key (e.g., 'TEST').
+        summary: The issue summary.
+        description: The issue description.
+        issue_type: The issue type (e.g., 'Task', 'Bug').
+        priority: The issue priority (e.g., 'Medium', 'High').
+        assignee: The username of the assignee.
+        extra_fields: Dictionary of additional fields to set (e.g., {'customfield_123': 'value', 'labels': ['label1']}).
+    """
     try:
         issue_dict = {
             "project": {"key": project_key},
@@ -351,6 +363,10 @@ def create_issue(
 
         if assignee:
             issue_dict["assignee"] = {"name": assignee}
+
+        # Merge extra fields
+        if extra_fields:
+            issue_dict.update(extra_fields)
 
         new_issue = get_jira_client(get_http_headers()).create_issue(fields=issue_dict)
         return f"Created issue {new_issue.key}: {summary}"

--- a/server.py
+++ b/server.py
@@ -3,6 +3,7 @@
 import os
 import argparse
 import types
+from typing import Literal
 from dotenv import load_dotenv
 from jira import JIRA
 from fastmcp import FastMCP
@@ -298,10 +299,14 @@ def list_boards(max_results: int = 10, project_key_or_id: str = None) -> str:
 
 
 @mcp.tool()
-def list_sprints(board_id: int, max_results: int = 10) -> str:
+def list_sprints(
+    board_id: int,
+    max_results: int = 10,
+    state: None | Literal["future"] | Literal["active"] | Literal["closed"] = None,
+) -> str:
     """List sprints for a board."""
     try:
-        sprints = get_jira_client(get_http_headers()).sprints(board_id, maxResults=max_results)
+        sprints = get_jira_client(get_http_headers()).sprints(board_id, maxResults=max_results, state=state)
         return to_markdown([s.raw for s in sprints])
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch sprints: {e}")

--- a/server.py
+++ b/server.py
@@ -136,7 +136,17 @@ def search_issues(jql: str, max_results: int = 100, extra_fields: list | None = 
 
     def simplify_issue(issue, extra_fields):
         """Extract only essential fields to avoid token limit issues"""
-        return {
+
+        def get_field_value(field):
+            if field is None:
+                return None
+            if hasattr(field, "name"):
+                return field.name
+            if isinstance(field, list):
+                return [get_field_value(item) for item in field]
+            return field
+
+        base_fields = {
             "key": issue.key,
             "summary": issue.fields.summary,
             "status": issue.fields.status.name if issue.fields.status else None,
@@ -153,7 +163,10 @@ def search_issues(jql: str, max_results: int = 100, extra_fields: list | None = 
             "created": issue.fields.created,
             "updated": issue.fields.updated,
             "description": issue.fields.description,
-        } | {k: getattr(issue.fields, k, None) for k in extra_fields}
+        }
+
+        extra = {k: get_field_value(getattr(issue.fields, k, None)) for k in extra_fields}
+        return base_fields | extra
 
     try:
         issues = get_jira_client(get_http_headers()).search_issues(jql, maxResults=max_results)

--- a/server.py
+++ b/server.py
@@ -11,7 +11,7 @@ from fastmcp.server.dependencies import get_http_headers
 from fastapi import HTTPException
 import json
 
-## Custom fields IDs
+# Custom fields IDs
 QA_CONTACT_FID = "customfield_12315948"
 
 # ─── 1. Load environment variables ─────────────────────────────────────────────

--- a/server.py
+++ b/server.py
@@ -365,7 +365,7 @@ def create_issue(
             issue_dict["assignee"] = {"name": assignee}
 
         if priority:
-            issue_dict["priority"] = ({"name": priority},)
+            issue_dict["priority"] = {"name": priority}
 
         # Merge extra fields
         if extra_fields:

--- a/server.py
+++ b/server.py
@@ -118,7 +118,7 @@ def to_markdown(obj):
 
 
 @mcp.tool()
-def search_issues(jql: str, max_results: int = 100, extra_fields: list = []) -> str:
+def search_issues(jql: str, max_results: int = 100, extra_fields: list | None = None) -> str:
     """
     Search for Jira issues using Jira Query Language (JQL).
 
@@ -131,6 +131,8 @@ def search_issues(jql: str, max_results: int = 100, extra_fields: list = []) -> 
         max_results: Maximum number of issues to return (default is 100).
         extra_fields: Optional list of additional Jira field names to include in each result.
     """
+
+    extra_fields = extra_fields or []
 
     def simplify_issue(issue, extra_fields):
         """Extract only essential fields to avoid token limit issues"""

--- a/server.py
+++ b/server.py
@@ -336,7 +336,7 @@ def create_issue(
     summary: str,
     description: str = "",
     issue_type: str = "Task",
-    priority: str = "Medium",
+    priority: str = None,
     assignee: str = None,
     extra_fields: dict = {},
 ) -> str:
@@ -358,11 +358,13 @@ def create_issue(
             "summary": summary,
             "description": description,
             "issuetype": {"name": issue_type},
-            "priority": {"name": priority},
         }
 
         if assignee:
             issue_dict["assignee"] = {"name": assignee}
+
+        if priority:
+            issue_dict["priority"] = {"name": priority},
 
         # Merge extra fields
         if extra_fields:

--- a/server.py
+++ b/server.py
@@ -57,18 +57,31 @@ mcp = FastMCP("Jira Context Server")
 
 
 # ─── 4. Register the get_jira tool ─────────────────────────────────────────────
+def _get_jira(issue_key: str) -> str:
+    try:
+        return get_jira_client(get_http_headers()).issue(issue_key)
+    except Exception as e:
+        # If the JIRA client raises an error (e.g. issue not found),
+        # wrap it in an HTTPException so MCP/Client sees a 4xx/5xx.
+        raise HTTPException(status_code=404, detail=f"Failed to fetch Jira issue {issue_key}: {e}")
+
+
+@mcp.tool()
+def get_jira_raw(issue_key: str) -> str:
+    """
+    Fetch the Jira issue identified by 'issue_key' using get_jira_client,
+    then return a row JSON representing all details about the Jira issue.
+    """
+    return to_markdown(_get_jira(issue_key))
+
+
 @mcp.tool()
 def get_jira(issue_key: str) -> str:
     """
     Fetch the Jira issue identified by 'issue_key' then
     return a Markdown string: "# ISSUE-KEY: summary\n\ndescription"
     """
-    try:
-        issue = get_jira_client(get_http_headers()).issue(issue_key)
-    except Exception as e:
-        # If the JIRA client raises an error (e.g. issue not found),
-        # wrap it in an HTTPException so MCP/Client sees a 4xx/5xx.
-        raise HTTPException(status_code=404, detail=f"Failed to fetch Jira issue {issue_key}: {e}")
+    issue = _get_jira(issue_key)
 
     # Extract summary & description fields
     summary = issue.fields.summary or ""
@@ -79,11 +92,11 @@ def get_jira(issue_key: str) -> str:
 
 def to_markdown(obj):
     if isinstance(obj, dict):
-        return "```json\n" + json.dumps(obj, indent=2) + "\n```"
+        return "```json\n" + json.dumps(obj, indent=2, sort_keys=True) + "\n```"
     elif hasattr(obj, "raw"):
-        return "```json\n" + json.dumps(obj.raw, indent=2) + "\n```"
+        return "```json\n" + json.dumps(obj.raw, indent=2, sort_keys=True) + "\n```"
     elif isinstance(obj, list) or isinstance(obj, types.GeneratorType):
-        return "\n".join((to_markdown(o) for o in obj))
+        return "\n".join([to_markdown(o) for o in obj])
     else:
         return str(obj)
 

--- a/server.py
+++ b/server.py
@@ -365,7 +365,7 @@ def create_issue(
             issue_dict["assignee"] = {"name": assignee}
 
         if priority:
-            issue_dict["priority"] = {"name": priority},
+            issue_dict["priority"] = ({"name": priority},)
 
         # Merge extra fields
         if extra_fields:
@@ -380,10 +380,11 @@ def create_issue(
 @mcp.tool(enabled=ENABLE_WRITE)
 def update_issue(
     issue_key: str,
-    summary: str = None,
-    description: str = None,
-    priority: str = None,
-    assignee: str = None,
+    summary: str | None = None,
+    description: str | None = None,
+    priority: str | None = None,
+    assignee: str | None = None,
+    extra_fields: dict = {},
 ) -> str:
     """Update an existing Jira issue."""
     try:
@@ -398,6 +399,10 @@ def update_issue(
             update_dict["priority"] = {"name": priority}
         if assignee:
             update_dict["assignee"] = {"name": assignee}
+
+        # Merge extra fields
+        if extra_fields:
+            update_dict.update(extra_fields)
 
         if update_dict:
             issue.update(fields=update_dict)

--- a/server.py
+++ b/server.py
@@ -336,8 +336,8 @@ def create_issue(
     summary: str,
     description: str = "",
     issue_type: str = "Task",
-    priority: str = None,
-    assignee: str = None,
+    priority: str | None = None,
+    assignee: str | None = None,
     extra_fields: dict = {},
 ) -> str:
     """
@@ -347,8 +347,8 @@ def create_issue(
         project_key: The project key (e.g., 'TEST').
         summary: The issue summary.
         description: The issue description.
-        issue_type: The issue type (e.g., 'Task', 'Bug').
-        priority: The issue priority (e.g., 'Medium', 'High').
+        issue_type: The issue type (e.g., 'Epic', 'Task', 'Bug').
+        priority: The issue priority (depends on project, e.g., 'Medium' or 'Normal').
         assignee: The username of the assignee.
         extra_fields: Dictionary of additional fields to set (e.g., {'customfield_123': 'value', 'labels': ['label1']}).
     """
@@ -358,6 +358,7 @@ def create_issue(
             "summary": summary,
             "description": description,
             "issuetype": {"name": issue_type},
+            "priority": {"name": "Undefined"},
         }
 
         if assignee:

--- a/server.py
+++ b/server.py
@@ -78,10 +78,15 @@ def get_jira_raw(issue_key: str) -> str:
 @mcp.tool()
 def get_jira(issue_key: str, extra_fields: list = []) -> str:
     """
-    Fetch the Jira issue identified by 'issue_key' then
-    return a Markdown string: "# ISSUE-KEY: summary\n\ndescription".
-    If 'extra_fields=["key1","key2"]' were provided, they will be added to the returned
-    string: "# ISSUE: summary\n\ndescription\n\nkey1 = value1\nkey2 = value2\n..."
+    Retrieve detailed information about a specific Jira issue in Markdown format.
+
+    Use this tool when you need to read the summary and description of a single issue.
+    By default, it returns the summary and description. Additional fields can be
+    requested via the 'extra_fields' parameter.
+
+    Args:
+        issue_key: The Jira issue key (e.g., 'TEST-123').
+        extra_fields: Optional list of additional Jira field names to include (e.g., ['priority', 'status', 'created']).
     """
     issue = _get_jira(issue_key)
 
@@ -113,8 +118,18 @@ def to_markdown(obj):
 
 @mcp.tool()
 def search_issues(jql: str, max_results: int = 100, extra_fields: list = []) -> str:
-    """Search issues using JQL.
-    You can also provide 'extra_fields' parameter with a list of additional fields to return."""
+    """
+    Search for Jira issues using Jira Query Language (JQL).
+
+    Use this tool to find issues matching specific criteria (e.g., project, status,
+    assignee, or keywords). It returns a list of issues with their core fields:
+    key, summary, status, assignee, reporter, priority, issuetype, fixVersion, etc.
+
+    Args:
+        jql: A valid Jira Query Language string (e.g., 'project = "PROJ" AND status = "Open"').
+        max_results: Maximum number of issues to return (default is 100).
+        extra_fields: Optional list of additional Jira field names to include in each result.
+    """
 
     def simplify_issue(issue, extra_fields):
         """Extract only essential fields to avoid token limit issues"""

--- a/server.py
+++ b/server.py
@@ -76,10 +76,12 @@ def get_jira_raw(issue_key: str) -> str:
 
 
 @mcp.tool()
-def get_jira(issue_key: str) -> str:
+def get_jira(issue_key: str, extra_fields: list = []) -> str:
     """
     Fetch the Jira issue identified by 'issue_key' then
-    return a Markdown string: "# ISSUE-KEY: summary\n\ndescription"
+    return a Markdown string: "# ISSUE-KEY: summary\n\ndescription".
+    If 'extra_fields' were provided, they will be added to the returned
+    string: "# ISSUE: summary\n\ndescription\n\nkey1 = value1\n..."
     """
     issue = _get_jira(issue_key)
 
@@ -87,7 +89,15 @@ def get_jira(issue_key: str) -> str:
     summary = issue.fields.summary or ""
     description = issue.fields.description or ""
 
-    return f"# {issue_key}: {summary}\n\n{description}"
+    output = f"# {issue_key}: {summary}\n\n{description}"
+
+    # If extra fields were requested, add the to the output as well
+    if extra_fields:
+        output += "\n"
+        for k in extra_fields:
+            output += f"\n{k} = {str(getattr(issue.fields, k, None))}"
+
+    return output
 
 
 def to_markdown(obj):
@@ -102,10 +112,11 @@ def to_markdown(obj):
 
 
 @mcp.tool()
-def search_issues(jql: str, max_results: int = 100) -> str:
-    """Search issues using JQL."""
+def search_issues(jql: str, max_results: int = 100, extra_fields: list = []) -> str:
+    """Search issues using JQL.
+    You can also provide 'extra_fields' parameter with a list of additional fields to return."""
 
-    def simplify_issue(issue):
+    def simplify_issue(issue, extra_fields):
         """Extract only essential fields to avoid token limit issues"""
         return {
             "key": issue.key,
@@ -124,6 +135,8 @@ def search_issues(jql: str, max_results: int = 100) -> str:
             "created": issue.fields.created,
             "updated": issue.fields.updated,
             "description": issue.fields.description,
+        } | {
+            k: getattr(issue.fields, k, None) for k in extra_fields
         }
 
     try:

--- a/server.py
+++ b/server.py
@@ -135,9 +135,7 @@ def search_issues(jql: str, max_results: int = 100, extra_fields: list = []) -> 
             "created": issue.fields.created,
             "updated": issue.fields.updated,
             "description": issue.fields.description,
-        } | {
-            k: getattr(issue.fields, k, None) for k in extra_fields
-        }
+        } | {k: getattr(issue.fields, k, None) for k in extra_fields}
 
     try:
         issues = get_jira_client(get_http_headers()).search_issues(jql, maxResults=max_results)

--- a/test_server.py
+++ b/test_server.py
@@ -254,6 +254,38 @@ class TestSearchIssues:
         assert exc_info.value.status_code == 400
         assert "JQL search failed" in str(exc_info.value.detail)
 
+    def test_search_issues_complex_field(self, mock_jira_client):
+        """Test search_issues with complex fields like Resolution and list of objects"""
+        # Create a mock issue
+        issue = MockJiraIssue("TEST-1", "First Issue")
+
+        # Create a complex object (like Resolution)
+        class ResolutionObj:
+            def __init__(self, name):
+                self.name = name
+
+        issue.fields.resolution = ResolutionObj("Fixed")
+
+        # Also test list of objects (like components)
+        class ComponentObj:
+            def __init__(self, name):
+                self.name = name
+
+        issue.fields.components = [ComponentObj("Frontend"), ComponentObj("Backend")]
+
+        mock_jira_client.search_issues.return_value = [issue]
+
+        result = server.search_issues.fn(
+            "project = TEST", max_results=50, extra_fields=["resolution", "components"]
+        )
+
+        assert "TEST-1" in result
+        assert "Fixed" in result # extracted from resolution.name
+        assert "Frontend" in result # extracted from components[0].name
+        assert "Backend" in result # extracted from components[1].name
+
+        mock_jira_client.search_issues.assert_called_once_with("project = TEST", maxResults=50)
+
 
 class TestProjectOperations:
     """Test project-related tools"""

--- a/test_server.py
+++ b/test_server.py
@@ -20,7 +20,11 @@ class MockJiraIssue:
 
     def __init__(self, key, summary="Test Summary", description="Test Description", **kwargs):
         self.key = key
-        self.fields = MagicMock()
+
+        class Fields:
+            pass
+
+        self.fields = Fields()
         self.fields.summary = summary
         self.fields.description = description
 
@@ -62,12 +66,12 @@ class MockJiraIssue:
 
         # Raw JSON, extremely simplified
         self.raw = {
-          "key": key,
-          "fields": {
-            "description": description,
-            "summary": summary,
-            "customfield_10000000": self.fields.customfield_10000000,
-          }
+            "key": key,
+            "fields": {
+                "description": description,
+                "summary": summary,
+                "customfield_10000000": self.fields.customfield_10000000,
+            },
         }
 
 
@@ -147,7 +151,10 @@ class TestGetJira:
 
         result = server.get_jira.fn("TEST-123", ["created", "updated"])
 
-        assert result == "# TEST-123: Test Issue\n\nThis is a test issue\n\ncreated = 2023-01-01T00:00:00.000+0000\nupdated = 2023-01-01T00:00:00.000+0000"
+        assert (
+            result
+            == "# TEST-123: Test Issue\n\nThis is a test issue\n\ncreated = 2023-01-01T00:00:00.000+0000\nupdated = 2023-01-01T00:00:00.000+0000"
+        )
         mock_jira_client.issue.assert_called_once_with("TEST-123")
 
     def test_get_jira_missing_fields(self, mock_jira_client):
@@ -163,7 +170,9 @@ class TestGetJira:
 
         result = server.get_jira.fn("TEST-123", ["does_not_exist"])
 
-        assert result.startswith("# TEST-123: Test Issue\n\nThis is a test issue\n\ndoes_not_exist = None")
+        assert result.startswith(
+            "# TEST-123: Test Issue\n\nThis is a test issue\n\ndoes_not_exist = None"
+        )
         mock_jira_client.issue.assert_called_once_with("TEST-123")
 
     def test_get_jira_not_found(self, mock_jira_client):
@@ -180,7 +189,14 @@ class TestGetJira:
 
         result = server.get_jira_raw.fn("TEST-123")
 
-        expected_data = {"key": sample_issue.key, "fields": {"description": sample_issue.fields.description, "summary": sample_issue.fields.summary, "customfield_10000000": 1}}
+        expected_data = {
+            "key": sample_issue.key,
+            "fields": {
+                "description": sample_issue.fields.description,
+                "summary": sample_issue.fields.summary,
+                "customfield_10000000": 1,
+            },
+        }
         assert result == "```json\n" + json.dumps(expected_data, indent=2, sort_keys=True) + "\n```"
         mock_jira_client.issue.assert_called_once_with("TEST-123")
 
@@ -211,7 +227,9 @@ class TestSearchIssues:
         ]
         mock_jira_client.search_issues.return_value = issues
 
-        result = server.search_issues.fn("project = TEST", max_results=50, extra_fields=["customfield_10000000"])
+        result = server.search_issues.fn(
+            "project = TEST", max_results=50, extra_fields=["customfield_10000000"]
+        )
 
         assert "TEST-1" in result
         assert "TEST-2" in result

--- a/test_server.py
+++ b/test_server.py
@@ -158,12 +158,12 @@ class TestGetJira:
 
         assert result == "# TEST-123: \n\n"
 
-    def test_get_jira_extra(self, mock_jira_client, sample_issue):
+    def test_get_jira_extra_not_found(self, mock_jira_client, sample_issue):
         mock_jira_client.issue.return_value = sample_issue
 
         result = server.get_jira.fn("TEST-123", ["does_not_exist"])
 
-        assert result.startswith("# TEST-123: Test Issue\n\nThis is a test issue\n\ndoes_not_exist = ")
+        assert result.startswith("# TEST-123: Test Issue\n\nThis is a test issue\n\ndoes_not_exist = None")
         mock_jira_client.issue.assert_called_once_with("TEST-123")
 
     def test_get_jira_not_found(self, mock_jira_client):

--- a/test_server.py
+++ b/test_server.py
@@ -57,15 +57,18 @@ class MockJiraIssue:
         self.update = MagicMock()
         self.delete = MagicMock()
 
+        # Custom fields
+        self.fields.customfield_10000000 = 1
+
         # Raw JSON, extremely simplified
         self.raw = {
           "key": key,
           "fields": {
             "description": description,
             "summary": summary,
+            "customfield_10000000": self.fields.customfield_10000000,
           }
         }
-
 
 
 class MockJiraProject:
@@ -139,6 +142,14 @@ class TestGetJira:
         assert result == "# TEST-123: Test Issue\n\nThis is a test issue"
         mock_jira_client.issue.assert_called_once_with("TEST-123")
 
+    def test_get_jira_extra(self, mock_jira_client, sample_issue):
+        mock_jira_client.issue.return_value = sample_issue
+
+        result = server.get_jira.fn("TEST-123", ["created", "updated"])
+
+        assert result == "# TEST-123: Test Issue\n\nThis is a test issue\n\ncreated = 2023-01-01T00:00:00.000+0000\nupdated = 2023-01-01T00:00:00.000+0000"
+        mock_jira_client.issue.assert_called_once_with("TEST-123")
+
     def test_get_jira_missing_fields(self, mock_jira_client):
         issue = MockJiraIssue("TEST-123", summary=None, description=None)
         mock_jira_client.issue.return_value = issue
@@ -146,6 +157,14 @@ class TestGetJira:
         result = server.get_jira.fn("TEST-123")
 
         assert result == "# TEST-123: \n\n"
+
+    def test_get_jira_extra(self, mock_jira_client, sample_issue):
+        mock_jira_client.issue.return_value = sample_issue
+
+        result = server.get_jira.fn("TEST-123", ["does_not_exist"])
+
+        assert result.startswith("# TEST-123: Test Issue\n\nThis is a test issue\n\ndoes_not_exist = ")
+        mock_jira_client.issue.assert_called_once_with("TEST-123")
 
     def test_get_jira_not_found(self, mock_jira_client):
         mock_jira_client.issue.side_effect = Exception("Issue not found")
@@ -161,7 +180,7 @@ class TestGetJira:
 
         result = server.get_jira_raw.fn("TEST-123")
 
-        expected_data = {"key": sample_issue.key, "fields": {"description": sample_issue.fields.description, "summary": sample_issue.fields.summary}}
+        expected_data = {"key": sample_issue.key, "fields": {"description": sample_issue.fields.description, "summary": sample_issue.fields.summary, "customfield_10000000": 1}}
         assert result == "```json\n" + json.dumps(expected_data, indent=2, sort_keys=True) + "\n```"
         mock_jira_client.issue.assert_called_once_with("TEST-123")
 
@@ -182,6 +201,23 @@ class TestSearchIssues:
         assert "TEST-2" in result
         assert "First Issue" in result
         assert "Second Issue" in result
+        assert '"customfield_10000000": 1' not in result
+        mock_jira_client.search_issues.assert_called_once_with("project = TEST", maxResults=50)
+
+    def test_search_issues_extra(self, mock_jira_client):
+        issues = [
+            MockJiraIssue("TEST-1", "First Issue"),
+            MockJiraIssue("TEST-2", "Second Issue", assignee="Jane Doe"),
+        ]
+        mock_jira_client.search_issues.return_value = issues
+
+        result = server.search_issues.fn("project = TEST", max_results=50, extra_fields=["customfield_10000000"])
+
+        assert "TEST-1" in result
+        assert "TEST-2" in result
+        assert "First Issue" in result
+        assert "Second Issue" in result
+        assert '"customfield_10000000": 1' in result
         mock_jira_client.search_issues.assert_called_once_with("project = TEST", maxResults=50)
 
     def test_search_issues_empty_result(self, mock_jira_client):

--- a/test_server.py
+++ b/test_server.py
@@ -347,6 +347,31 @@ class TestWriteOperations:
         assert call_args["assignee"]["name"] == "john.doe"
 
     @patch("server.ENABLE_WRITE", True)
+    def test_create_issue_with_extra_fields(self, mock_jira_client):
+        new_issue = MockJiraIssue("TEST-457", "Extra Fields Issue")
+        mock_jira_client.create_issue.return_value = new_issue
+
+        extra_fields = {
+            "customfield_123": "value",
+            "labels": ["label1", "label2"],
+        }
+
+        result = server.create_issue.fn(
+            project_key="TEST",
+            summary="Extra Fields Issue",
+            extra_fields=extra_fields,
+        )
+
+        assert "Created issue TEST-457" in result
+        mock_jira_client.create_issue.assert_called_once()
+
+        call_args = mock_jira_client.create_issue.call_args[1]["fields"]
+        assert call_args["project"]["key"] == "TEST"
+        assert call_args["summary"] == "Extra Fields Issue"
+        assert call_args["customfield_123"] == "value"
+        assert call_args["labels"] == ["label1", "label2"]
+
+    @patch("server.ENABLE_WRITE", True)
     def test_update_issue_success(self, mock_jira_client, sample_issue):
         mock_jira_client.issue.return_value = sample_issue
 

--- a/test_server.py
+++ b/test_server.py
@@ -383,6 +383,23 @@ class TestWriteOperations:
         sample_issue.update.assert_called_once()
 
     @patch("server.ENABLE_WRITE", True)
+    def test_update_issue_with_extra_fields(self, mock_jira_client, sample_issue):
+        mock_jira_client.issue.return_value = sample_issue
+
+        extra_fields = {
+            "customfield_123": "value",
+            "labels": ["label1"],
+        }
+
+        result = server.update_issue.fn(issue_key="TEST-123", extra_fields=extra_fields)
+
+        assert "Updated issue TEST-123 successfully" in result
+        sample_issue.update.assert_called_once()
+        call_args = sample_issue.update.call_args[1]["fields"]
+        assert call_args["customfield_123"] == "value"
+        assert call_args["labels"] == ["label1"]
+
+    @patch("server.ENABLE_WRITE", True)
     def test_add_comment_success(self, mock_jira_client, sample_issue):
         mock_jira_client.issue.return_value = sample_issue
         comment = MockJiraComment("comment-123", "Test comment")

--- a/test_server.py
+++ b/test_server.py
@@ -611,7 +611,18 @@ class TestBoardsAndSprints:
 
         assert "Sprint 1" in result
         assert "Sprint 2" in result
-        mock_jira_client.sprints.assert_called_once_with(123, maxResults=10)
+        mock_jira_client.sprints.assert_called_once_with(123, maxResults=10, state=None)
+
+    def test_list_sprints_with_state(self, mock_jira_client):
+        sprints = [
+            MagicMock(raw={"id": 1, "name": "Active Sprint", "state": "active"}),
+        ]
+        mock_jira_client.sprints.return_value = sprints
+
+        result = server.list_sprints.fn(board_id=123, max_results=10, state="active")
+
+        assert "Active Sprint" in result
+        mock_jira_client.sprints.assert_called_once_with(123, maxResults=10, state="active")
 
     def test_get_sprint_success(self, mock_jira_client):
         sprint = MagicMock(raw={"id": 456, "name": "Test Sprint", "state": "active"})

--- a/test_server.py
+++ b/test_server.py
@@ -2,6 +2,7 @@
 
 import pytest
 import os
+import json
 from unittest.mock import patch, MagicMock
 from fastapi import HTTPException
 

--- a/test_server.py
+++ b/test_server.py
@@ -57,6 +57,16 @@ class MockJiraIssue:
         self.update = MagicMock()
         self.delete = MagicMock()
 
+        # Raw JSON, extremely simplified
+        self.raw = {
+          "key": key,
+          "fields": {
+            "description": description,
+            "summary": summary,
+          }
+        }
+
+
 
 class MockJiraProject:
     """Mock Jira project object"""
@@ -145,6 +155,15 @@ class TestGetJira:
 
         assert exc_info.value.status_code == 404
         assert "Failed to fetch Jira issue NONEXISTENT-123" in str(exc_info.value.detail)
+
+    def test_get_jira_raw(self, mock_jira_client, sample_issue):
+        mock_jira_client.issue.return_value = sample_issue
+
+        result = server.get_jira_raw.fn("TEST-123")
+
+        expected_data = {"key": sample_issue.key, "fields": {"description": sample_issue.fields.description, "summary": sample_issue.fields.summary}}
+        assert result == "```json\n" + json.dumps(expected_data, indent=2, sort_keys=True) + "\n```"
+        mock_jira_client.issue.assert_called_once_with("TEST-123")
 
 
 class TestSearchIssues:


### PR DESCRIPTION
Thank you for this useful MCP server!

There is a lot of issue custom fields that are not exposed neither via issue search or getting issue. This adds a "last resort" call to get the full huge JSON issue representation.