### PR TITLE
Fix Cloud JQL search HTTP 410 by upgrading jira to 3.10.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ httpx-sse==0.4.0
 idna==3.10
 iniconfig==2.1.0
 isodate==0.7.2
-jira==3.8.0
+jira==3.10.5
 jsonschema==4.25.1
 jsonschema-path==0.3.4
 jsonschema-specifications==2025.9.1

--- a/server.py
+++ b/server.py
@@ -88,6 +88,22 @@ def to_markdown(obj):
         return str(obj)
 
 
+# Fields needed by search_issues; the Cloud /search/jql API returns IDs only unless fields are set.
+SEARCH_ISSUE_FIELDS = [
+    "summary",
+    "status",
+    "assignee",
+    QA_CONTACT_FID,
+    "reporter",
+    "priority",
+    "issuetype",
+    "fixVersion",
+    "created",
+    "updated",
+    "description",
+]
+
+
 @mcp.tool()
 def search_issues(jql: str, max_results: int = 100) -> str:
     """Search issues using JQL."""
@@ -114,7 +130,12 @@ def search_issues(jql: str, max_results: int = 100) -> str:
         }
 
     try:
-        issues = get_jira_client(get_http_headers()).search_issues(jql, maxResults=max_results)
+        client = get_jira_client(get_http_headers())
+        # jira>=3.10 routes Cloud calls to /rest/api/*/search/jql (legacy /search was removed).
+        # Data Center keeps using the classic search endpoint via the same method.
+        issues = client.search_issues(
+            jql, maxResults=max_results, fields=SEARCH_ISSUE_FIELDS
+        )
         return to_markdown((simplify_issue(issue) for issue in issues))
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"JQL search failed: {e}")

--- a/test_server.py
+++ b/test_server.py
@@ -163,7 +163,11 @@ class TestSearchIssues:
         assert "TEST-2" in result
         assert "First Issue" in result
         assert "Second Issue" in result
-        mock_jira_client.search_issues.assert_called_once_with("project = TEST", maxResults=50)
+        mock_jira_client.search_issues.assert_called_once_with(
+            "project = TEST",
+            maxResults=50,
+            fields=server.SEARCH_ISSUE_FIELDS,
+        )
 
     def test_search_issues_empty_result(self, mock_jira_client):
         mock_jira_client.search_issues.return_value = []


### PR DESCRIPTION
## Summary
- Bump `jira` from `3.8.0` to `3.10.5` so Cloud `search_issues` uses `/rest/api/*/search/jql` instead of the removed `/rest/api/2/search`
- Request explicit fields in `search_issues` (Cloud `/search/jql` returns issue IDs only by default)
- Update unit tests for the new `fields=` argument

Fixes #37

## Context
Jira Cloud removed the legacy search endpoints, causing `search_issues` to fail with HTTP 410:
